### PR TITLE
Refactor exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
 		"php": "^7.0",
      	"guzzlehttp/guzzle": "~6.0",
-        "laravel/framework": "^5.5"
+        "laravel/framework": "^5.5",
+        "laravel/passport": "^4.0"
     },
     "autoload": {
         "psr-4": {"DesignMyNight\\Laravel\\OAuth2\\": "src/"}

--- a/src/Exceptions/InvalidAccessTokenException.php
+++ b/src/Exceptions/InvalidAccessTokenException.php
@@ -1,6 +1,0 @@
-<?php
-namespace DesignMyNight\Laravel\OAuth2\Exceptions;
-
-class InvalidAccessTokenException extends \Exception
-{
-}

--- a/src/Exceptions/InvalidEndpointException.php
+++ b/src/Exceptions/InvalidEndpointException.php
@@ -1,6 +1,0 @@
-<?php
-namespace DesignMyNight\Laravel\OAuth2\Exceptions;
-
-class InvalidEndpointException extends InvalidAccessTokenException
-{
-}

--- a/src/Exceptions/InvalidInputException.php
+++ b/src/Exceptions/InvalidInputException.php
@@ -1,6 +1,0 @@
-<?php
-namespace DesignMyNight\Laravel\OAuth2\Exceptions;
-
-class InvalidInputException extends InvalidAccessTokenException
-{
-}

--- a/src/VerifyAccessToken.php
+++ b/src/VerifyAccessToken.php
@@ -85,12 +85,6 @@ class VerifyAccessToken
      */
     public function handle($request, Closure $next, ...$scopes)
     {
-        $authorization = $request->header('Authorization');
-
-        if (!$authorization) {
-            throw new AuthenticationException('No Authorization header present');
-        }
-
         $bearerToken = $request->bearerToken();
 
         if (!$bearerToken) {

--- a/src/VerifyAccessToken.php
+++ b/src/VerifyAccessToken.php
@@ -88,7 +88,7 @@ class VerifyAccessToken
                 $result = json_decode((string) $e->getResponse()->getBody(), true);
 
                 if (isset($result['error'])) {
-                    throw new AuthenticationException($result['error']['title']);
+                    throw new AuthenticationException($result['error']['title'] ?? '');
                 }
             }
 

--- a/src/VerifyAccessToken.php
+++ b/src/VerifyAccessToken.php
@@ -14,6 +14,19 @@ class VerifyAccessToken
 
     private $client = null;
 
+    protected function checkScopes($scopesForToken, $requiredScopes)
+    {
+        if (!is_array($requiredScopes)) {
+            $requiredScopes = [$requiredScopes];
+        }
+
+        $misingScopes = array_diff($scopesForToken, $scopesForToken);
+
+        if (count($misingScopes) > 0) {
+            throw new MissingScopeException($misingScopes);
+        }
+    }
+
     private function getClient(): Client
     {
         if ($this->client === null) {
@@ -98,17 +111,8 @@ class VerifyAccessToken
                 throw new AuthenticationException('Invalid token!');
             }
 
-            if ($scopes != null) {
-                if (!\is_array($scopes)) {
-                    $scopes = [$scopes];
-                }
-
-                $scopesForToken = \explode(' ', $result['scope']);
-                $misingScopes = array_diff($scopes, $scopesForToken);
-
-                if (count($misingScopes) > 0) {
-                    throw new MissingScopeException($misingScopes);
-                }
+            if ($scopes !== null) {
+                $this->checkScopes(explode(' ', $result['scope']), $scopes);
             }
         } catch (RequestException $e) {
             if ($e->hasResponse()) {

--- a/src/VerifyAccessToken.php
+++ b/src/VerifyAccessToken.php
@@ -115,13 +115,11 @@ class VerifyAccessToken
                 $result = json_decode((string) $e->getResponse()->getBody(), true);
 
                 if (isset($result['error'])) {
-                    throw new AuthenticationException($result['error']['title'] ?? 'Invalid token!');
+                    throw new AuthenticationException($result['error']['title']);
                 }
-
-                throw new AuthenticationException('Invalid token!');
             }
 
-            throw new AuthenticationException($e);
+            throw new AuthenticationException($e->getMessage());
         }
 
         return $next($request);

--- a/src/VerifyAccessToken.php
+++ b/src/VerifyAccessToken.php
@@ -88,7 +88,7 @@ class VerifyAccessToken
         $bearerToken = $request->bearerToken();
 
         if (!$bearerToken) {
-            throw new AuthenticationException('No Bearer token in the Authorization header present');
+            throw new AuthenticationException('No Bearer token present');
         }
 
         try {


### PR DESCRIPTION
The main change here is to replace the custom `Exception` classes and instead use Laravel's `AuthenticationException` and Passport's `MissingScopeException`.

This ensures that if a user makes a request which doesn't authenticate the response is a 401 rather than a 500 due to the unhandled exception.