### PR TITLE
feat: ability to override the user model

### DIFF
--- a/config/authorizationserver.php
+++ b/config/authorizationserver.php
@@ -1,11 +1,20 @@
 <?php
 
 return [
+
     'authorization_url' => env('AUTHORIZATION_SERVER_AUTHORIZATION_URL'),
+
     'redirect_url' => env('AUTHORIZATION_SERVER_REDIRECT_URL'),
+
     'token_url' => env('AUTHORIZATION_SERVER_TOKEN_URL'),
+
     'introspect_url' => env('AUTHORIZATION_SERVER_INTROSPECT_URL'),
+
     'client_id' => env('AUTHORIZATION_SERVER_CLIENT_ID'),
+
     'client_secret' => env('AUTHORIZATION_SERVER_CLIENT_SECRET'),
+
     'scope' => env('AUTHORIZATION_SERVER_SCOPE'),
+
+    'model' => \Illuminate\Foundation\Auth\User::class
 ];

--- a/src/Introspect.php
+++ b/src/Introspect.php
@@ -15,12 +15,13 @@ class Introspect
     protected $client = null;
     protected $result;
     protected $userDataKey = 'user';
-    protected $userModelClass = User::class;
+    protected $userModelClass;
 
     public function __construct(IntrospectClient $client, Request $request)
     {
         $this->client = $client;
         $this->request = $request;
+        $this->setUserModelClass(config('authorizationserver.model', User::class));
     }
 
     protected function getIntrospectionResult()


### PR DESCRIPTION
Currently you are unable to override the the `User` model when using the introspect middleware. This change allows you to set the user model in the config.